### PR TITLE
Remove repack slots flag

### DIFF
--- a/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
+++ b/src/python/WMCore/BossAir/Plugins/SimpleCondorPlugin.py
@@ -551,9 +551,8 @@ class SimpleCondorPlugin(BasePlugin):
                 ad['My.DESIRED_CMSPileups'] = classad.quote(str(cmsPileups))
             else:
                 ad['My.DESIRED_CMSPileups'] = undefined
-            # HighIO and repack jobs
+            # HighIO
             ad['My.Requestioslots'] = str(1 if job['task_type'] in ["Merge", "Cleanup", "LogCollect"] else 0)
-            ad['My.RequestRepackslots'] = str(1 if job['task_type'] == 'Repack' else 0)
             # Performance and resource estimates (including JDL magic tweaks)
             origCores = job.get('numberOfCores', 1)
             estimatedMins = int(job['estimatedJobTime'] / 60.0) if job.get('estimatedJobTime') else 12 * 60


### PR DESCRIPTION
Fixes #<GH_Issue_Number>

#### Status
not-tested

#### Description
Removing flags that requests special slots for Repack jobs. I'll allow us to test repack performance when we are able to take over entire workernodes.

#### Is it backward compatible (if not, which system it affects?)
YES 
