### PR TITLE
Run PostScramScript before cmsRun

### DIFF
--- a/src/python/WMCore/WMRuntime/Scripts/PostScramScript.sh
+++ b/src/python/WMCore/WMRuntime/Scripts/PostScramScript.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Post SCRAM Script"

--- a/src/python/WMCore/WMRuntime/Unpacker.py
+++ b/src/python/WMCore/WMRuntime/Unpacker.py
@@ -87,6 +87,13 @@ def createWorkArea(sandbox):
         os.write(fd, startupScript)
         os.close(fd)
 
+    # need to pull out the startup file from the zipball
+    with zipfile.ZipFile(os.path.join(jobDir, 'WMCore.zip'), 'r') as zfile:
+        startupScript = zfile.read('WMCore/WMRuntime/Scripts/PostScramScript.sh')
+        fd = os.open(os.path.join(jobDir, 'PostScramScript.sh'), os.O_CREAT | os.O_WRONLY)
+        os.write(fd, startupScript)
+        os.close(fd)
+
     logging.info("PYTHONPATH=%s", os.environ.get("PYTHONPATH"))
 
     return jobDir

--- a/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
+++ b/src/python/WMCore/WMSpec/Steps/Executors/CMSSW.py
@@ -236,6 +236,11 @@ class CMSSW(Executor):
         with open(configPath, 'w') as handle:
             handle.write(CONFIG_BLOB)
 
+        # Running scripts before cmsRun execution
+        logging.info("RUNNING POST SCRAM SCRIPTS")
+        results = subprocess.run(["sh", "../../PostScramScript.sh"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        logging.info(results.stdout)
+
         # spawn this new process
         # the script looks for:
         # <SCRAM_COMMAND> <SCRAM_PROJECT> <CMSSW_VERSION> <JOB_REPORT> <EXECUTABLE> <CONFIG>


### PR DESCRIPTION
Adds the PostScramScript in
```
src/python/WMCore/WMRuntime/Scripts/PostScramScript.sh
```

Can be used to run commands before calling `cmsRun` during execution.