### PR TITLE
Disable write recovery for XRDCP

### DIFF
--- a/src/python/WMCore/Storage/Backends/XRDCPImpl.py
+++ b/src/python/WMCore/Storage/Backends/XRDCPImpl.py
@@ -106,8 +106,8 @@ class XRDCPImpl(StageOutImpl):
             if os.path.isfile(initFile):
                 copyCommand += "source %s\n" % initFile
 
-        if args.wma_disablewriterecovery:
-            copyCommand += "env XRD_WRITERECOVERY=0 "
+        # if args.wma_disablewriterecovery:
+        copyCommand += "env XRD_WRITERECOVERY=0 "
 
         if args.wma_preload:
             xrdcpCmd = "%s xrdcp" % args.wma_preload


### PR DESCRIPTION
Disables write recovery for all calls to xrdcp. Stageout then relies on StageOut retries to handle transfer failures.
