### PR TITLE
Bypasses job locations query

### DIFF
--- a/src/python/WMComponent/JobCreator/JobCreatorPoller.py
+++ b/src/python/WMComponent/JobCreator/JobCreatorPoller.py
@@ -561,7 +561,8 @@ class JobCreatorPoller(BaseWorkerThread):
                     tempDict.update(processDict)
                     tempDict['jobGroup'] = wmbsJobGroup
                     tempDict['jobNumber'] = jobNumber
-                    tempDict['inputDatasetLocations'] = wmbsJobGroup.getLocationsForJobs()
+                    #tempDict['inputDatasetLocations'] = wmbsJobGroup.getLocationsForJobs()
+                    tempDict['inputDatasetLocations'] = ['T2_CH_CERN']
 
                     jobGroup = creatorProcess(work=tempDict,
                                               jobCacheDir=self.jobCacheDir)


### PR DESCRIPTION
Fixes JobCreator slowdowns caused by inefficient `getLocationsForJobs` query.

This is a workaround. The proper fix requires action by Oracle DBA:
https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC3993729

